### PR TITLE
bugfix: fix wrong API url

### DIFF
--- a/lib/wechat/http.ex
+++ b/lib/wechat/http.ex
@@ -6,7 +6,7 @@ defmodule Wechat.HTTP do
       use HTTPoison.Base
 
       def process_url(url) do
-        unquote(opts)[:host] <> url
+        Path.join(unquote(opts)[:host], url)
       end
 
       def process_response_body(body) do


### PR DESCRIPTION
Hi, thanks for the great work, really excited to find an Elixir package for Wechat. 👍 

I came across with a bug failing with sending custom messages.

```elixir
iex(1)> Wechat.Message.Custom.send_text "SOME_OPENID", "HI"

17:30:39.585 [debug] post to message/custom/send

17:30:39.586 [debug] %{"msgtype" => "text", "text" => %{"content" => "HI"}, "touser" => "SOME_OPENID"}
%HTTPoison.Response{body: "",
 headers: [{"Connection", "keep-alive"},
  {"Date", "Sun, 30-Jul-2017 09:30:39 GMT"}, {"Content-Length", "0"}],
 request_url: "https://api.weixin.qq.com/cgi-binmessage/custom/send?access_token=bZD4HtHW2NGrgbDs8VEziB0Snz5XLb5TKT2yjpjPZZGt-xKVGgR0qc4beZgVQHAt4AmwdrA70ku1zAPJaxbJNtrPld9TXKSqDwW9_xu2-SXayuGvyFQJEPsyG3Ctx8vWTPAgABACYJ",
 status_code: 404}
""
```

It just failed silently. Notice the url `https://api.weixin.qq.com/cgi-binmessage/custom/send`
It's bad idea to [join path segments with `<>`](https://github.com/goofansu/wechat-elixir/blob/bf21067f1bf67ffe338398a41e32a0b0adc995ff/lib/wechat/http.ex#L9). I changed it into `Path.join/2`.

Please take a review. I hope it will help.
Thanks.