### PR TITLE
Enable fetching access token with a custom method

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -34,5 +34,12 @@ config :wechat, Wechat,
   token: {:system, "WECHAT_TOKEN"},
   encoding_aes_key: {:system, "WECHAT_AES_KEY"}
 
-config :wechat, Wechat,
-  access_token_fetcher: {Wechat.API, :access_token, []}
+# To define your own method to fetch the access token, you can provide
+# a `access_token_fetcher` here. This is useful when you are sharing
+# access_token among multiple applications and you pull access_token
+# from a center storage or other service.
+#
+# The syntax is: {Module, method, [args]}
+#
+#     config :wechat, Wechat,
+#       access_token_fetcher: {Wechat.API, :access_token, []}

--- a/config/config.exs
+++ b/config/config.exs
@@ -33,3 +33,6 @@ config :wechat, Wechat,
   secret: {:system, "WECHAT_SECRET"},
   token: {:system, "WECHAT_TOKEN"},
   encoding_aes_key: {:system, "WECHAT_AES_KEY"}
+
+config :wechat, Wechat,
+  access_token_fetcher: {Wechat.API, :access_token, []}

--- a/lib/wechat/workers/access_token.ex
+++ b/lib/wechat/workers/access_token.ex
@@ -7,6 +7,7 @@ defmodule Wechat.Workers.AccessToken do
 
   @name __MODULE__
   @refresh_interval :timer.minutes(30)
+  @default_fetcher {API, :access_token, []}
 
   def start_link(args) do
     GenServer.start_link(__MODULE__, args, name: @name)
@@ -28,7 +29,12 @@ defmodule Wechat.Workers.AccessToken do
 
   defp do_refresh do
     Process.send_after(self(), :refresh, @refresh_interval)
-    API.access_token
+
+    {mod, f, args} = :wechat
+    |> Application.get_env(Wechat)
+    |> Keyword.get(:access_token_fetcher, @default_fetcher)
+
+    apply(mod, f, args)
   end
 
   def get do

--- a/test/wechat/access_token_worker_test.exs
+++ b/test/wechat/access_token_worker_test.exs
@@ -1,0 +1,24 @@
+defmodule Wechat.Worker.AccessTokenTest do
+  use ExUnit.Case, async: false
+
+  alias Wechat.Workers.AccessToken
+  
+  test "custom fetcher" do
+    Application.put_env(
+      :wechat,
+      Wechat,
+      [access_token_fetcher: {__MODULE__, :fetch_token, []}]
+    )
+
+    AccessToken.start_link([])
+    Process.send AccessToken, :refresh, []
+
+    assert GenServer.call(AccessToken, :get) == "test" 
+  end
+
+  def fetch_token do
+    %{"access_token" => "test"}
+  end
+
+end
+


### PR DESCRIPTION
Regarding `Wechat.API.access_token` for wechat server, I want to fetch token from other data sources because in our case access_token is  sharing among several different applications. Each application would not refresh access token by its own. They fetch access token from a independent service instead.

So I added a method to allow myself to config a different method to fetch token.

Please have a review on this, thanks.