### PR TITLE
more custom message types supported

### DIFF
--- a/fixture/vcr_cassettes/send_link.json
+++ b/fixture/vcr_cassettes/send_link.json
@@ -1,0 +1,23 @@
+[
+  {
+    "request": {
+      "body": "{\"touser\":\"oi00OuKAhA8bm5okpaIDs7WmUZr4\",\"msgtype\":\"link\",\"link\":{\"url\":\"http://www.example.com\",\"title\":\"Awesome webpage\",\"thumb_url\":\"https://gitlab.com/gitlab-com/gitlab-artwork/raw/master/logo/logo.png\",\"description\":\"Click and you will go\"}}",
+      "headers": [],
+      "method": "post",
+      "options": [],
+      "request_body": "",
+      "url": "https://api.weixin.qq.com/cgi-bin/message/custom/send?access_token=F2NaQM2ac5JlVOi7Qt3b-ICZwpAr-riCbYiegDNV4eR8kykbBMKyDGezSQvADm124n9UXJx-xFwowUv-vqdOcd0uJ1keZ2-pzNWXfdNIIu0NgBsDDQKcEPBpjBrYHycYQUJcAGAIMB"
+    },
+    "response": {
+      "body": "{\"errcode\":0,\"errmsg\":\"ok\"}",
+      "headers": {
+        "Connection": "keep-alive",
+        "Content-Type": "application/json; encoding=utf-8",
+        "Date": "Mon, 31 Jul 2017 06:40:14 GMT",
+        "Content-Length": "27"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/fixture/vcr_cassettes/send_mini_program_app_page.json
+++ b/fixture/vcr_cassettes/send_mini_program_app_page.json
@@ -1,0 +1,23 @@
+[
+  {
+    "request": {
+      "body": "{\"touser\":\"oi00OuKAhA8bm5okpaIDs7WmUZr4\",\"msgtype\":\"miniprogrampage\",\"miniprogrampage\":{\"title\":\"my mini program app\",\"pagepath\":\"/pages/index\",\"thumb_media_id\":\"111\"}}",
+      "headers": [],
+      "method": "post",
+      "options": [],
+      "request_body": "",
+      "url": "https://api.weixin.qq.com/cgi-bin/message/custom/send?access_token=F2NaQM2ac5JlVOi7Qt3b-ICZwpAr-riCbYiegDNV4eR8kykbBMKyDGezSQvADm124n9UXJx-xFwowUv-vqdOcd0uJ1keZ2-pzNWXfdNIIu0NgBsDDQKcEPBpjBrYHycYQUJcAGAIMB"
+    },
+    "response": {
+      "body": "{\"errcode\":0,\"errmsg\":\"ok\"}",
+      "headers": {
+        "Connection": "keep-alive",
+        "Content-Type": "application/json; encoding=utf-8",
+        "Date": "Mon, 31 Jul 2017 06:40:14 GMT",
+        "Content-Length": "27"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/lib/wechat/message/custom.ex
+++ b/lib/wechat/message/custom.ex
@@ -7,7 +7,7 @@ defmodule Wechat.Message.Custom do
   alias Wechat.API
 
   @api_path "/message/custom/send"
-  @types ~w(text image voice video music news mpnews wxcard)
+  @types ~w(text image voice video music news mpnews wxcard link miniprogrampage)
 
   def send_text(openid, content) do
     message =
@@ -91,6 +91,18 @@ defmodule Wechat.Message.Custom do
                        "card_ext" => card_ext
                      })
 
+    deliver(openid, message)
+  end
+
+  # REF: 
+  # https://mp.weixin.qq.com/debug/wxadoc/dev/api/custommsg/conversation.html
+  def send_link(openid, content) do
+    message = build_message("link", content)
+    deliver(openid, message)
+  end
+
+  def send_mini_program_app_page(openid, content) do
+    message = build_message("miniprogrampage", content)
     deliver(openid, message)
   end
 

--- a/test/wechat/message/custom_test.exs
+++ b/test/wechat/message/custom_test.exs
@@ -17,4 +17,29 @@ defmodule Wechat.Message.CustomTest do
       assert result["errmsg"] == "ok"
     end
   end
+
+  test "send link", %{openid: openid} do
+    use_cassette "send_link" do
+      result = Custom.send_link(openid, %{
+        title: "Awesome webpage",
+        description: "Click and you will go",
+        url: "http://www.example.com",
+        thumb_url: "https://gitlab.com/gitlab-com/gitlab-artwork/raw/master/logo/logo.png"
+      })
+      assert result["errcode"] == 0
+      assert result["errmsg"] == "ok"
+    end
+  end
+
+  test "send weapp page", %{openid: openid} do
+    use_cassette "send_mini_program_app_page" do
+      result = Custom.send_mini_program_app_page(openid, %{
+        title: "my mini program app",
+        pagepath: "/pages/index?id=1",
+        thumb_media_id: "111"
+      })
+      assert result["errcode"] == 0
+      assert result["errmsg"] == "ok"
+    end
+  end
 end


### PR DESCRIPTION
This is an update for Weapp (小程序) custom message API.  
Reference: https://mp.weixin.qq.com/debug/wxadoc/dev/api/custommsg/conversation.html

Two APIs are added:

* `Wechat.Message.Custom.send_link/2`
* `Wechat.Message.Custom.send_mini_program_app_page/2`